### PR TITLE
勤怠詳細画面への遷移のバグ修正

### DIFF
--- a/app/src/main/java/com/valjapan/kintai/WorkDataDetailActivity.kt
+++ b/app/src/main/java/com/valjapan/kintai/WorkDataDetailActivity.kt
@@ -20,15 +20,12 @@ class WorkDataDetailActivity : AppCompatActivity() {
         setContentView(R.layout.activity_work_data_detail)
         realm = Realm.getDefaultInstance()
 
-        Log.d("Log", intent.getStringExtra("startDate"))
-
-        val sdFormat = SimpleDateFormat("EEE MM dd HH:mm:ss z yyyy", Locale.JAPANESE)
-        dateFormat = sdFormat.parse("Wed Nov 06 23:47:48 GMT+09:00 2019")
-        Log.d("Log", dateFormat.toString())
+        val dataId = intent.getStringExtra("id") ?: ""
+        Log.d("dataId", dataId)
 
 
         val data = realm?.where(WorkData::class.java)
-            ?.equalTo("startTime", dateFormat)
+            ?.equalTo("id", dataId)
             ?.findFirst()
 
         val startTime = data?.startTime

--- a/app/src/main/java/com/valjapan/kintai/adapter/RealmViewAdapter.kt
+++ b/app/src/main/java/com/valjapan/kintai/adapter/RealmViewAdapter.kt
@@ -60,7 +60,7 @@ class RealmViewAdapter(
 
             val context: Context = context
             val intent = Intent(context, WorkDataDetailActivity::class.java)
-            intent.putExtra("startDate", works?.startTime.toString())
+            intent.putExtra("id", works?.id)
 
             Log.d("Log", works?.startTime.toString())
             context.startActivity(intent)

--- a/app/src/main/java/com/valjapan/kintai/adapter/WorkData.kt
+++ b/app/src/main/java/com/valjapan/kintai/adapter/WorkData.kt
@@ -1,9 +1,11 @@
 package com.valjapan.kintai.adapter
 
 import io.realm.RealmObject
+import io.realm.annotations.PrimaryKey
 import java.util.*
 
 open class WorkData : RealmObject() {
+    @PrimaryKey open var id: String? = null
     var startTime: Date? = null
     var finishTime: Date? = null
     var ssid: String? = null

--- a/app/src/main/java/com/valjapan/kintai/fragment/AddWorkLogFragment.kt
+++ b/app/src/main/java/com/valjapan/kintai/fragment/AddWorkLogFragment.kt
@@ -87,7 +87,7 @@ class AddWorkLogFragment : Fragment() {
 
     private fun addRealm(ssid: String) {
         realm!!.executeTransaction {
-            workData = it.createObject(WorkData::class.java)
+            workData = it.createObject(WorkData::class.java, UUID.randomUUID().toString()) // PrimaryKeyとなるプロパティの値を入れる
             workData.startTime = nowDate()
             workData.finishTime = null
             workData.ssid = ssid


### PR DESCRIPTION
## やったこと
- ModelにPrimaryKeyとなるidを追加
- id使ってrealmからデータを取得するようにした

## この実装の理由
- 基本的に1件だけ検索したい場合は、一般的にPrimaryKeyとなるユニークなプロパティで絞った方が良さそう
- 今回の場合は開始時刻や終了時刻が自分で変えられる仕様なのもあるので、時刻はPrimaryKeyとして適切ではないかなと
- 具体的な案として、WorkDataに`id: Int` というユニークなプロパティを追加し、そのidをintentに渡してrealmから検索する形でいけそう